### PR TITLE
Refactor: 定数の型を厳密化し、命名を改善

### DIFF
--- a/app/expense/additional/page.tsx
+++ b/app/expense/additional/page.tsx
@@ -10,22 +10,8 @@ import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { CalendarIcon, PlusIcon} from "lucide-react"
-
-interface Expense {
-  id: string
-  date: string
-  amount: number
-  category: string
-  memo: string
-  createdAt: number
-}
-
-const categories = [
-  { value: "food", label: "食費" },
-  { value: "living", label: "生活費" },
-  { value: "fixed", label: "固定費" },
-  { value: "misc", label: "雑費" },
-]
+import { Expense } from "@/types/expense"
+import { categories } from "@/constants/categories"
 
 export default function ExpenseInputForm() {
   const [expenses, setExpenses] = useState<Expense[]>([])

--- a/app/expense/additional/page.tsx
+++ b/app/expense/additional/page.tsx
@@ -12,6 +12,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { CalendarIcon, PlusIcon} from "lucide-react"
 import { Expense } from "@/types/expense"
 import { EXPENSE_CATEGORIES } from "@/constants/expense-categories"
+import { saveExpenses, loadExpenses } from "@/utils/storage"
 
 export default function ExpenseInputForm() {
   const [expenses, setExpenses] = useState<Expense[]>([])
@@ -21,11 +22,6 @@ export default function ExpenseInputForm() {
     category: "",
     memo: "",
   })
-
-  // localStorageにデータを保存
-  const saveToLocalStorage = (newExpenses: Expense[]) => {
-    localStorage.setItem("expenses", JSON.stringify(newExpenses))
-  }
 
   // 支出を追加
   const handleAddExpense = (e: React.FormEvent) => {
@@ -44,7 +40,7 @@ export default function ExpenseInputForm() {
     }
     const updatedExpenses = [newExpense, ...expenses]
     setExpenses(updatedExpenses)
-    saveToLocalStorage(updatedExpenses)
+    saveExpenses(updatedExpenses)
 
     // フォームをリセット（日付は今日のまま）
     setFormData({

--- a/app/expense/additional/page.tsx
+++ b/app/expense/additional/page.tsx
@@ -12,7 +12,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { CalendarIcon, PlusIcon} from "lucide-react"
 import { Expense } from "@/types/expense"
 import { EXPENSE_CATEGORIES } from "@/constants/expense-categories"
-import { saveExpenses, loadExpenses } from "@/utils/storage"
+import { saveExpenses } from "@/utils/storage"
 
 export default function ExpenseInputForm() {
   const [expenses, setExpenses] = useState<Expense[]>([])

--- a/app/expense/additional/page.tsx
+++ b/app/expense/additional/page.tsx
@@ -11,7 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea"
 import { CalendarIcon, PlusIcon} from "lucide-react"
 import { Expense } from "@/types/expense"
-import { categories } from "@/constants/categories"
+import { EXPENSE_CATEGORIES } from "@/constants/expense-categories"
 
 export default function ExpenseInputForm() {
   const [expenses, setExpenses] = useState<Expense[]>([])
@@ -113,7 +113,7 @@ export default function ExpenseInputForm() {
                     <SelectValue placeholder="カテゴリを選択してください" />
                   </SelectTrigger>
                   <SelectContent>
-                    {categories.map((category) => (
+                    {EXPENSE_CATEGORIES.map((category) => (
                       <SelectItem key={category.value} value={category.value}>
                         {category.label}
                       </SelectItem>

--- a/app/expense/dashboard/page.tsx
+++ b/app/expense/dashboard/page.tsx
@@ -11,14 +11,10 @@ import { Trash2Icon } from "lucide-react"
 import { ColumnDef } from "@tanstack/react-table"
 import { DataTable } from "./dataTable"
 import { Expense } from "@/types/expense"
-import { EXPENSE_CATEGORIES,EPENSE_CATEGORY_COLORS } from "@/constants/expense-categories"
+import { EPENSE_CATEGORY_COLORS } from "@/constants/expense-categories"
 import { formatAmount, formatDate } from "@/utils/format"
 import { saveExpenses, loadExpenses } from "@/utils/storage"
-
-// カテゴリ名を取得
-const getCategoryLabel = (value: string) => {
-  return EXPENSE_CATEGORIES.find((cat) => cat.value === value)?.label || value
-}
+import { getExpenseCategoryLabel } from "@/utils/expense"
 
 // テーブル列の定義
 const columns: ColumnDef<Expense>[] = [
@@ -34,7 +30,7 @@ const columns: ColumnDef<Expense>[] = [
     accessorKey: "category",
     header: "カテゴリ",
     cell:({row}) => {
-      return <Badge className={EPENSE_CATEGORY_COLORS[row.original.category as keyof typeof EPENSE_CATEGORY_COLORS]}>{getCategoryLabel(row.original.category)}</Badge>
+      return <Badge className={EPENSE_CATEGORY_COLORS[row.original.category as keyof typeof EPENSE_CATEGORY_COLORS]}>{getExpenseCategoryLabel(row.original.category)}</Badge>
     },
   },
 ]
@@ -96,7 +92,7 @@ export default function ExpenseDashboard() {
                         <div className="flex items-center gap-3">
                           <span className="text-sm text-gray-500">{formatDate(expense.date)}</span>
                           <Badge className={EPENSE_CATEGORY_COLORS[expense.category as keyof typeof EPENSE_CATEGORY_COLORS]}>
-                            {getCategoryLabel(expense.category)}
+                            {getExpenseCategoryLabel(expense.category)}
                           </Badge>
                         </div>
                         <div className="flex items-center justify-between">

--- a/app/expense/dashboard/page.tsx
+++ b/app/expense/dashboard/page.tsx
@@ -11,14 +11,7 @@ import { Trash2Icon } from "lucide-react"
 import { ColumnDef } from "@tanstack/react-table"
 import { DataTable } from "./dataTable"
 import { Expense } from "@/types/expense"
-import { EXPENSE_CATEGORIES } from "@/constants/expense-categories"
-
-const categoryColors = {
-  food: "bg-orange-100 text-orange-800",
-  living: "bg-blue-100 text-blue-800",
-  fixed: "bg-purple-100 text-purple-800",
-  misc: "bg-gray-100 text-gray-800",
-}
+import { EXPENSE_CATEGORIES,EPENSE_CATEGORY_COLORS } from "@/constants/expense-categories"
 
 // カテゴリ名を取得
 const getCategoryLabel = (value: string) => {
@@ -39,7 +32,7 @@ const columns: ColumnDef<Expense>[] = [
     accessorKey: "category",
     header: "カテゴリ",
     cell:({row}) => {
-      return <Badge className={categoryColors[row.original.category as keyof typeof categoryColors]}>{getCategoryLabel(row.original.category)}</Badge>
+      return <Badge className={EPENSE_CATEGORY_COLORS[row.original.category as keyof typeof EPENSE_CATEGORY_COLORS]}>{getCategoryLabel(row.original.category)}</Badge>
     },
   },
 ]
@@ -133,7 +126,7 @@ export default function ExpenseDashboard() {
                       <div className="flex-1 space-y-2">
                         <div className="flex items-center gap-3">
                           <span className="text-sm text-gray-500">{formatDate(expense.date)}</span>
-                          <Badge className={categoryColors[expense.category as keyof typeof categoryColors]}>
+                          <Badge className={EPENSE_CATEGORY_COLORS[expense.category as keyof typeof EPENSE_CATEGORY_COLORS]}>
                             {getCategoryLabel(expense.category)}
                           </Badge>
                         </div>

--- a/app/expense/dashboard/page.tsx
+++ b/app/expense/dashboard/page.tsx
@@ -11,7 +11,7 @@ import { Trash2Icon } from "lucide-react"
 import { ColumnDef } from "@tanstack/react-table"
 import { DataTable } from "./dataTable"
 import { Expense } from "@/types/expense"
-import { categories } from "@/constants/categories"
+import { EXPENSE_CATEGORIES } from "@/constants/expense-categories"
 
 const categoryColors = {
   food: "bg-orange-100 text-orange-800",
@@ -22,7 +22,7 @@ const categoryColors = {
 
 // カテゴリ名を取得
 const getCategoryLabel = (value: string) => {
-  return categories.find((cat) => cat.value === value)?.label || value
+  return EXPENSE_CATEGORIES.find((cat) => cat.value === value)?.label || value
 }
 
 // テーブル列の定義

--- a/app/expense/dashboard/page.tsx
+++ b/app/expense/dashboard/page.tsx
@@ -10,22 +10,8 @@ import { Badge } from "@/components/ui/badge"
 import { Trash2Icon } from "lucide-react"
 import { ColumnDef } from "@tanstack/react-table"
 import { DataTable } from "./dataTable"
-
-interface Expense {
-  id: string
-  date: string
-  amount: number
-  category: string
-  memo: string
-  createdAt: number
-}
-
-const categories = [
-  { value: "food", label: "食費" },
-  { value: "living", label: "生活費" },
-  { value: "fixed", label: "固定費" },
-  { value: "misc", label: "雑費" },
-]
+import { Expense } from "@/types/expense"
+import { categories } from "@/constants/categories"
 
 const categoryColors = {
   food: "bg-orange-100 text-orange-800",

--- a/app/expense/dashboard/page.tsx
+++ b/app/expense/dashboard/page.tsx
@@ -12,6 +12,8 @@ import { ColumnDef } from "@tanstack/react-table"
 import { DataTable } from "./dataTable"
 import { Expense } from "@/types/expense"
 import { EXPENSE_CATEGORIES,EPENSE_CATEGORY_COLORS } from "@/constants/expense-categories"
+import { formatAmount, formatDate } from "@/utils/format"
+import { saveExpenses, loadExpenses } from "@/utils/storage"
 
 // カテゴリ名を取得
 const getCategoryLabel = (value: string) => {
@@ -37,52 +39,19 @@ const columns: ColumnDef<Expense>[] = [
   },
 ]
 
-
-
 export default function ExpenseDashboard() {
   const [expenses, setExpenses] = useState<Expense[]>([])
-  // const [formData, setFormData] = useState({
-  //   date: new Date().toISOString().split("T")[0],
-  //   amount: "",
-  //   category: "",
-  //   memo: "",
-  // })
   // localStorageからデータを読み込み
   useEffect(() => {
-    const savedExpenses = localStorage.getItem("expenses")
-    if (savedExpenses) {
-      setExpenses(JSON.parse(savedExpenses))
-    }
+    setExpenses(loadExpenses())
   }, [])
   
-  // localStorageにデータを保存
-  const saveToLocalStorage = (newExpenses: Expense[]) => {
-    localStorage.setItem("expenses", JSON.stringify(newExpenses))
-  }
   // 支出を削除
   const handleDeleteExpense = (id: string) => {
     const updatedExpenses = expenses.filter((expense) => expense.id !== id)
     setExpenses(updatedExpenses)
-    saveToLocalStorage(updatedExpenses)
+    saveExpenses(updatedExpenses)
   }
-  // 金額をフォーマット
-  const formatAmount = (amount: number) => {
-    return new Intl.NumberFormat("ja-JP", {
-      style: "currency",
-      currency: "JPY",
-    }).format(amount)
-  }
-
-  // 日付をフォーマット
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
-    return date.toLocaleDateString("ja-JP", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    })
-  }
-
 
   return (
     <div className="min-h-screen bg-gray-50 py-8">

--- a/constants/categories.ts
+++ b/constants/categories.ts
@@ -1,0 +1,7 @@
+// Expense category definitions
+export const categories = [
+  { value: "food", label: "食費" },
+  { value: "living", label: "生活費" },
+  { value: "fixed", label: "固定費" },
+  { value: "misc", label: "雑費" },
+]

--- a/constants/expense-categories.ts
+++ b/constants/expense-categories.ts
@@ -1,5 +1,5 @@
 // Expense category definitions
-export const categories = [
+export const EXPENSE_CATEGORIES = [
   { value: "food", label: "食費" },
   { value: "living", label: "生活費" },
   { value: "fixed", label: "固定費" },

--- a/constants/expense-categories.ts
+++ b/constants/expense-categories.ts
@@ -4,4 +4,4 @@ export const EXPENSE_CATEGORIES = [
   { value: "living", label: "生活費" },
   { value: "fixed", label: "固定費" },
   { value: "misc", label: "雑費" },
-]
+] as const;

--- a/constants/expense-categories.ts
+++ b/constants/expense-categories.ts
@@ -5,3 +5,12 @@ export const EXPENSE_CATEGORIES = [
   { value: "fixed", label: "固定費" },
   { value: "misc", label: "雑費" },
 ] as const;
+
+// Expense category colors definitions
+export const EPENSE_CATEGORY_COLORS = {
+  food: "bg-orange-100 text-orange-800",
+  living: "bg-blue-100 text-blue-800",
+  fixed: "bg-purple-100 text-purple-800",
+  misc: "bg-gray-100 text-gray-800",
+} as const;
+

--- a/types/expense.ts
+++ b/types/expense.ts
@@ -1,0 +1,9 @@
+// Expense type definition
+export interface Expense {
+  id: string
+  date: string
+  amount: number
+  category: string
+  memo: string
+  createdAt: number
+}

--- a/utils/expense.ts
+++ b/utils/expense.ts
@@ -1,0 +1,6 @@
+import { EXPENSE_CATEGORIES } from "@/constants/expense-categories"
+
+// 支出カテゴリ名を取得
+export const getExpenseCategoryLabel = (value: string) => {
+  return EXPENSE_CATEGORIES.find((cat) => cat.value === value)?.label || value
+}

--- a/utils/format.ts
+++ b/utils/format.ts
@@ -1,0 +1,15 @@
+export const formatDate = (dateString: string) => {
+    const date = new Date(dateString)
+    return date.toLocaleDateString("ja-JP", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+    })
+}
+
+export const formatAmount = (amount: number) => {
+    return new Intl.NumberFormat("ja-JP", {
+        style: "currency",
+        currency: "JPY",
+    }).format(amount)
+}

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,0 +1,19 @@
+import { Expense } from "@/types/expense"
+
+// localStorageにデータを保存
+export const saveExpenses = (newExpenses: Expense[]) => {
+    localStorage.setItem("expenses", JSON.stringify(newExpenses))
+}
+
+// localStorageからデータを読み込み
+export const loadExpenses = ():Expense[] => {
+    const savedExpenses = localStorage.getItem("expenses")
+    if (savedExpenses) {
+        try {
+            return JSON.parse(savedExpenses)
+        } catch {
+            return []
+        }
+    }
+    return []
+}


### PR DESCRIPTION
## 背景
現在の定数定義では型が緩く、意図しない値が代入される可能性があり。
また、命名が抽象的でわかりにくい部分があったため修正。

## 変更内容
1. **リテラル型の厳密化**
   - `as const` を追加して定数の型をリテラル型に変更
   - TypeScriptでの型チェックがより厳密になる
   - 例: `"FOOD"` | `"TRANSPORT"` のように固定値として扱われる

2. **定数名の改善**
   - すべて大文字に変更し、具体的な意味を反映
   - 例: `categories` → `CATEGORY_LIST`

3. **定数・型の共通化**
   - 複数箇所で使われていた定数や型を1か所にまとめ、再利用性を向上

## 影響範囲
- TypeScriptの型チェックにより、定数の誤用が検出されやすくなる
- 命名が明確になったため、コード可読性が向上

## 補足
- 動作自体に大きな変更なし
- 型安全性と可読性向上が主目的
